### PR TITLE
Projekt Übersicht

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,3 +11,7 @@ url: "codeformuenster.org" # the base hostname & protocol for your site
 # Build settings
 markdown: kramdown
 permalink: /:categories/:year/:month/:day/:title/
+
+collections:
+  projekte:
+      output: true

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,11 +6,11 @@
     <a href="javascript:void(0)" class="navigation-menu-button" id="js-mobile-menu">MENU</a>
     <nav role="navigation">
       <ul id="js-navigation-menu" class="navigation-menu show">
+        <li class="nav-link"><a href="{{ "/projekte/" | prepend: site.baseurl }}">Projekte</a></li>
         <li class="nav-link"><a href="{{ "/blog/index.html" | prepend: site.baseurl }}">Blog</a></li>
         <li class="nav-link"><a target="_blank" href="http://forum.codeformuenster.org/">Mitmachen</a></li>
         <li class="nav-link"><a href="http://codeformuenster.org/blog/2014/11/26/getting-started/">Über uns</a></li>
         <li class="nav-link"><a target="_blank" href="http://www.meetup.com/OK-Lab-Munster/">Nächstes Treffen</a></li>
-        <li class="nav-link"><a target="_blank" href="http://codefor.de/muenster/index.html#projects">Projekte</a></li>
         <li class="nav-link"><a target="_blank" href="http://eepurl.com/OIlwT">Newsletter Anmeldung</a></li>
       </ul>
     </nav>

--- a/_layouts/projekt.html
+++ b/_layouts/projekt.html
@@ -1,0 +1,18 @@
+---
+layout: default
+page_class: project
+---
+<div class="wrapper">
+  <h2><a href="{{ "/projekte/" | prepend: site.baseurl }}">Projekte</a></h2>
+  <div class="project">
+
+    <header class="project-header">
+      <h2 class="project-title">{{ page.title }}</h2>
+    </header>
+
+    <article class="project-content">
+      {{ content }}
+    </article>
+
+  </div>
+</div>

--- a/_projekte/offener-haushalt.md
+++ b/_projekte/offener-haushalt.md
@@ -1,0 +1,10 @@
+---
+title: Offener Haushalt Münster
+status: Abgeschlossen
+github: haushalt-muenster
+link: http://offenerhaushalt.de/haushalt/muenster
+description: Haushalt der Stadt Münster 2009-2012
+members:
+  - name: Mila
+layout: projekt
+---

--- a/_projekte/offener-rat.md
+++ b/_projekte/offener-rat.md
@@ -1,0 +1,11 @@
+---
+title: Offener Rat
+status: in Progress
+github: offenerrat-ms
+link: http://rat.codeformuenster.org
+description: Das offene Ratsinformationssystem für Münster
+members:
+  - name: Mila
+layout: projekt
+---
+## Transparenz in den Gremien

--- a/_projekte/parkleitsystem-api.md
+++ b/_projekte/parkleitsystem-api.md
@@ -1,0 +1,10 @@
+---
+title: Parkleitsystem API Münster
+status: Abgeschlossen
+github: parkleitsystem-api
+link: http://codeformuenster.org/parkleitsystem-api
+description: Ein Wrapper für das Parkleitsystem des Tiefbauamts Münster
+members:
+  - name: Gerald
+layout: projekt
+---

--- a/_projekte/poll-finder.md
+++ b/_projekte/poll-finder.md
@@ -1,0 +1,10 @@
+---
+title: Wahllokalfinder
+status: in Progress
+github: poll-finder
+link: http://poll-finder.codeformuenster.org
+description: Finde dein Wahllokal API
+members:
+  - name: Mila
+layout: projekt
+---

--- a/_projekte/runnermap.md
+++ b/_projekte/runnermap.md
@@ -1,0 +1,10 @@
+---
+title: Runnermap Münster
+status: Abgeschlossen
+github: muenster-runnermap
+link: http://codeformuenster.org/muenster-runnermap
+description: Karte mit den beliebtesten Laufrouten in Münster
+members:
+  - name: Gerald
+layout: projekt
+---

--- a/_projekte/wahl-kandidatenliste.md
+++ b/_projekte/wahl-kandidatenliste.md
@@ -1,0 +1,10 @@
+---
+title: Kandidatenliste der Kommunalwahl 2014
+status: In Progress
+github: kandidatenliste
+link: http://codeformuenster.org/kandidatenliste
+description: Eine Karte mit den Kandidaten der Kommunalwahl 2014
+members:
+  - name: Simon
+layout: projekt
+---

--- a/_projekte/wahlen.md
+++ b/_projekte/wahlen.md
@@ -1,0 +1,10 @@
+---
+title: Wahlübersicht nach Bezirken
+status: in Progress
+github: wahlen
+link: http://codeformuenster.org/wahlen
+description: Wahlübersicht nach Bezirken
+members:
+  - name: Mila
+layout: projekt
+---

--- a/_projekte/wahlkarte.md
+++ b/_projekte/wahlkarte.md
@@ -1,0 +1,10 @@
+---
+title: Wahlkarte
+status: in Progress
+github: wahlkarte
+link: http://codeformuenster.org/wahlkarte
+description: Wahlergebnisse der Kommunalwahl 2014
+members:
+  - name: Mila
+layout: projekt
+---

--- a/_projekte/wahlprogramm-matrix.md
+++ b/_projekte/wahlprogramm-matrix.md
@@ -1,0 +1,10 @@
+---
+title: Wahlprogramm-Matrix
+status: Abgeschlossen
+github: wahlprogramm-matrix
+link: http://codeformuenster.org/wahlprogramm-matrix
+description: Finde ähnliche Passagen in Wahlprogrammen
+members:
+  - name: Daniel
+layout: projekt
+---

--- a/_projekte/weihnachtsmarkt.md
+++ b/_projekte/weihnachtsmarkt.md
@@ -1,0 +1,10 @@
+---
+title: Weihnachtsmarkt-App Münster 2014
+status: In Progress
+github: weihnachtsmarkt
+link: http://codeformuenster.org/weihnachtsmarkt
+description: Eine Karte mit den Ständen des Weihnachtsmarktes 2014
+members:
+  - name: Gerald
+layout: projekt
+---

--- a/_sass/_base.scss
+++ b/_sass/_base.scss
@@ -22,6 +22,7 @@ $on-laptop:        800px;
 @import "blog";
 @import "meetup";
 @import "main";
+@import "projects";
 
 body {
   padding: 0;

--- a/_sass/_projects.sass
+++ b/_sass/_projects.sass
@@ -1,0 +1,22 @@
+.wrapper
+  @include outer-container()
+#projects
+  @include span-columns(10)
+  padding: 1em
+  color: #fff
+  ul
+    margin: 1em 0
+    li.project
+      margin: 1em 0
+      padding: 1em
+      background: rgba(3,3,3,0.8)
+      +clearfix
+      .details
+        border-top: 1px solid #fff
+        ul
+          li
+            float: left
+            font-size: 1.5em
+            padding: 0 2em 0 0
+            i
+              padding: 0 0.5em 0 0

--- a/projekte/index.html
+++ b/projekte/index.html
@@ -1,0 +1,23 @@
+---
+layout: default
+title: Code for Münster
+---
+<div class="wrapper">
+  <div id="projects">
+    <ul>
+      {% for projekt in site.projekte %}
+        <li class="project">
+          <h2>{{projekt.title}}</h2>
+          <p>{{projekt.description}}</p>
+          <div class="details">
+            <ul>
+              <li><a href="{{projekt.link}}"><i class="fa fa-globe"></i>Webseite</a></li>
+              <li><a href="http://github.com/codeformuenster/{{projekt.github}}"><i class="fa fa-github"></i>Code</a></li>
+              <li><i class="fa fa-rocket"></i>{{projekt.status}}</li>
+            </ul>
+          </div>
+        </li>
+      {% endfor %}
+    </ul>
+  </div>
+</div>


### PR DESCRIPTION
Hab mal ne Projekt Übersicht angelegt.
Wenn die Über uns Seite gemerged ist, dann wird die Seite das Münster Bild als Hintergrund haben.

Projekte sind Collections. Einfach unter `_projekte` ein md File anlegen und im Frontmatter ein paar Details ausfüllen. 
Später soll dann eine Detailseite kommen, aber erstmal reicht die Übersicht.
## Screenshot

![bildschirmfoto 2015-01-19 um 08 45 17](https://cloud.githubusercontent.com/assets/688980/5797350/9ec1942c-9fb8-11e4-8daf-aa44a2630a7d.png)

Habt ihr Ideen wie man eine Sortierung machen könnte?
