### PR TITLE
Revert "Beschreibung des Projekts "Wahlkarte" verbessern"

### DIFF
--- a/_projekte/wahlkarte.md
+++ b/_projekte/wahlkarte.md
@@ -3,7 +3,7 @@ title: Wahlkarte
 status: in Progress
 github: wahlkarte
 link: http://codeformuenster.org/wahlkarte
-description: Webseite mit Suchmaske, auf der ein Besucher durch Eingabe von Straße und Hausnummer oder Wahlbezirk seine Kandidaten zur Kommunalwahl 2014 und die Ergebnisse der Wahl 2009 erfährt.
+description: Wahlergebnisse der Kommunalwahl 2014
 members:
   - name: Mila
 layout: projekt


### PR DESCRIPTION
Reverts codeformuenster/codeformuenster.github.io#26

Die längere Beschreibung gehört eigentlich zum Projekt "Wahlübersicht nach Bezirken"
