### PR TITLE
Remove past open data day

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,6 @@
         <li class="nav-link"><a href="{{ "/blog/index.html" | prepend: site.baseurl }}">Blog</a></li>
         <li class="nav-link"><a target="_blank" href="http://forum.codeformuenster.org/">Mitmachen</a></li>
         <li class="nav-link"><a target="_blank" href="http://www.meetup.com/OK-Lab-Munster/">Nächstes Treffen</a></li>
-        <li class="nav-link"><a target="_blank" href="http://codeformuenster.org/opendataday">Open Data Day 2015</a></li>
       </ul>
     </nav>
   </div>


### PR DESCRIPTION
It's over and the page for the odd doesn't show any results, so better remove it.
