### PR TITLE
Fixes #31: Add twitter button

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,3 +2,4 @@
 </footer>
 <script src="https://code.jquery.com/jquery-2.1.3.min.js"></script>
 <script src="{{ "/js/main.js" | prepend: site.baseurl }}"></script>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -9,13 +9,13 @@ category: blog
   <div class="post">
 
     <header class="post-header">
-      <div class="date">{{page.date || date: "%d.%m.%Y"}} | {{page.author}}</div>
+      <div class="date">{{page.date || date: "%d.%m.%Y"}} | {{page.author}} | <a href="https://twitter.com/share" class="twitter-share-button" data-via="codeformuenster" data-count="none" data-related="codeformuenster">Tweet</a></div>
       <h2 class="post-title">{{ page.title }}</h2>
     </header>
 
     <article class="post-content">
       {{ content }}
     </article>
-
+    <a href="https://twitter.com/share" class="twitter-share-button" data-count="none" data-via="codeformuenster" data-related="codeformuenster">Tweet</a>
   </div>
 </div>


### PR DESCRIPTION
Dies löst #31 und fügt einen Twitter Button hinzu.

Für bessere "conversion rates" sowohl am Anfang als auch am Ende jedes Blogposts.
<img width="541" alt="bildschirmfoto 2015-11-08 um 13 59 21" src="https://cloud.githubusercontent.com/assets/1255372/11020533/a8915eec-8621-11e5-92f2-182cedde85ed.png">
<img width="649" alt="bildschirmfoto 2015-11-08 um 13 59 32" src="https://cloud.githubusercontent.com/assets/1255372/11020534/a8b1f666-8621-11e5-8ecc-8e583efc923b.png">
