### PR TITLE
Date format fixes

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,7 +21,7 @@ category: blog
           </h1>
 
           <p class="uk-article-meta">
-            Verfasst von {{page.author}} am {{page.date || date: "%d.%m.%Y"}}
+            Verfasst von {{page.author}} am {{page.date | date: "%d.%m.%Y"}}
              in "{{page.category}}"
 
 

--- a/blog/index.html
+++ b/blog/index.html
@@ -22,7 +22,7 @@ page_class: blog
               </h1>
 
               <p class="uk-article-meta">
-                Verfasst von {{post.author}} am {{ post.date | date: "%-d %B %Y" }}
+                Verfasst von {{post.author}} am {{ post.date | date: "%d.%m.%Y" }}
                  in <a href="{{ post.url }}">{{post.category}}</a>
                </p>
 

--- a/index.html
+++ b/index.html
@@ -179,9 +179,9 @@ title: Code for Münster
               </h2>
 
               <p class="uk-article-meta">
-                Verfasst von {{site.posts[0].author}} am {{ site.posts[0].date | date: "%-d %B %Y" }}
-                 in <a href="{{ "/blog/index.html" | prepend: site.baseurl }}">{{site.posts[0].category}}</a>
-               </p>
+                Verfasst von {{site.posts[0].author}} am {{ site.posts[0].date | date: "%d.%m.%Y" }}
+                    in <a href="{{ "/blog/index.html" | prepend: site.baseurl }}">{{site.posts[0].category}}</a>
+              </p>
 
               <p> {{ site.posts[0].excerpt }}
               </p>
@@ -197,9 +197,9 @@ title: Code for Münster
               </h2>
 
               <p class="uk-article-meta">
-                Verfasst von {{site.posts[1].author}} am {{ site.posts[1].date | date: "%-d %B %Y" }}
-                 in <a href="{{ "/blog/index.html" | prepend: site.baseurl }}">{{site.posts[1].category}}</a>
-               </p>
+                Verfasst von {{site.posts[1].author}} am {{ site.posts[1].date | date: "%d.%m.%Y" }}
+                in <a href="{{ "/blog/index.html" | prepend: site.baseurl }}">{{site.posts[1].category}}</a>
+              </p>
 
               <p> {{ site.posts[1].excerpt }}
               </p>


### PR DESCRIPTION
Datum wurde bei manchen Blogbeiträgen mit 05 march 2018 angezeigt. Ich glaube da wäre 05.05.2018 eine bessere Wahl.

Zudem war in _layouts/post.html ein Syntaxfehler, welcher die ganze Zeit Warnungen produziert hat.

![screenshot_244](https://user-images.githubusercontent.com/12571895/52732579-dda03080-2fc0-11e9-8e2c-beeb40fc4678.png)
