### PR TITLE
check for total_tasks == 0 to prevent NaN in progressBar

### DIFF
--- a/index.html
+++ b/index.html
@@ -270,7 +270,12 @@ a.issues:hover {
     }
 
     function showProject( container, p, noimage ) {
-        var percent = p.closed_tasks  / p.total_tasks  * 100;
+        var percent = 0.0;
+        if(p.total_tasks == 0) {
+          percent = 50.0;
+        } else {
+          percent = p.closed_tasks  / p.total_tasks  * 100;
+        }
 
         var featureIcon = "";
         featureIcon = ((p.status=='done')||(p.status=='ok'))?'star':'';


### PR DESCRIPTION
This copies work in #64 to fix #50, but instead of setting the percent value to 100 it's set to 50. Also no changes to indent levels are made to stay clear of merge conflicts.