### PR TITLE
Fix fürs Karousel auf der Hauptseite

### DIFF
--- a/index.md
+++ b/index.md
@@ -41,10 +41,10 @@ carousel_images:
     <div class="Carousel-slide">
       {% if item.link %}
         <a href="{{ item.link }}" class="Carousel-item">
-          <img loading="lazy" src="{{ full_path }}" alt="{{ item.alt }}">
+          <img loading="eager" src="{{ full_path }}" alt="{{ item.alt }}">
         </a>
       {% else %}
-        <img loading="lazy" src="{{ full_path }}" class="Carousel-item" alt="{{ item.alt }}">
+        <img loading="eager" src="{{ full_path }}" class="Carousel-item" alt="{{ item.alt }}">
       {% endif %}
     </div>
     {% endfor %}


### PR DESCRIPTION
Sonst werden die Bilder erst geladen wenn die Animation zuende ist.